### PR TITLE
add fix for background color option override

### DIFF
--- a/src/components/StaticAnnotation.tsx
+++ b/src/components/StaticAnnotation.tsx
@@ -46,7 +46,7 @@ function StaticAnnotation({
   const styles = options.annoStyles || {};
   const [showName, setShowName] = useState<boolean>(false);
   // color-code by type
-  const backgroundColor = rainbowMode ? getColor(types, type) : 'none';
+  const backgroundColor = rainbowMode ? getColor(types, type) : options.annoStyles.backgroundColor;
 
   const calculateTooltipPosition = () => {
     const leftCoord = pixelToNum(width) / 2 - 100;


### PR DESCRIPTION
If I pass in backgroundColor from options.annoStyles, I was unable to see that color reflected in the annotation box background. And if someone doesn't pass a backgroundColor, it will still not show it with this code change.